### PR TITLE
Update Go and Kasm Dockerfiles to latest versions

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,5 @@
 #
+# 2025-04-09 marktmilligan/go:1.24.0
 # 2024-08-30 martkmilligan/go:1.23.0
 # 2024-03-15 marktmilligan/go:1.22.1
 # 2023-12-23 pushed to marktmilligan/go.1.21.5 with
@@ -13,11 +14,13 @@
 # dockerfile
 FROM codercom/enterprise-base:ubuntu
 
+ARG GO_RELEASE="1.24.0"
+
 # run everything as root
 USER root
 
 # install go
-RUN curl -L "https://dl.google.com/go/go1.23.0.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
+RUN curl -L "https://dl.google.com/go/go${GO_RELEASE}.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
 
 # Setup go env vars
 ENV GOROOT /usr/local/go

--- a/kasm/Dockerfile
+++ b/kasm/Dockerfile
@@ -1,13 +1,14 @@
 #
 # https://kasmweb.com/docs/latest/guide/custom_images.html
-# https://github.com/Kong/insomnia/releases
+# https://github.com/kasmtech/KasmVNC/releases
+# https://docs.docker.com/desktop/setup/install/linux/ubuntu/
 #
-# 2024-08-15 built and pushed image to docker.io marktmilligan/kasn:latest 8.2.0, kasm 1.15.0
-# 2023-10-14 built and pushed image to docker.io marktmilligan/kasn:latest 8.2.0, kasm 1.12.0
-# 2023-02-11 built and pushed image to docker.io marktmilligan/kasn:latest 2023.2.2, kasm 1.14.0
-#
+# 2024-08-15 built and pushed image to docker.io marktmilligan/kasm:latest 8.2.0, kasm 1.15.0
+# 2023-10-14 built and pushed image to docker.io marktmilligan/kasm:latest 8.2.0, kasm 1.12.0
+# 2023-02-11 built and pushed image to docker.io marktmilligan/kasm:latest 2023.2.2, kasm 1.14.0
+# 2025-04-09 built and pushed image to docker.io marktmilligan/kasm:latest, kasm 1.16.1
 
-FROM kasmweb/desktop:1.15.0
+FROM kasmweb/desktop:1.16.1
 
 USER root
 
@@ -19,11 +20,6 @@ RUN apt-get update && apt-get install sudo
 RUN echo "kasm-user ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 RUN DEBIAN_FRONTEND=noninteractive make-ssl-cert generate-default-snakeoil --force-overwrite
 RUN adduser kasm-user ssl-cert
-
-# Install Insomnia
-RUN wget -O wget -O /tmp/insomnia.deb https://github.com/Kong/insomnia/releases/download/core%409.3.3/Insomnia.Core-9.3.3.deb && \
-    dpkg -i /tmp/insomnia.deb && \
-    rm /tmp/insomnia.deb
 
 # Install baseline packages
 RUN apt-get update && \


### PR DESCRIPTION
- Updated Go to version 1.24.0
- Updated Kasm to version 1.16.1
- Removed Insomnia installation from Kasm Dockerfile